### PR TITLE
Correct `dub.json` to use `sourcePaths` / `importPaths`, make examples use HEAD

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -9,6 +9,6 @@
 	"dependencies": {
 	},
 	"systemDependencies": "requires HDF5 1.8.15.patch-1 versions of libhdf5 and libhdf5_hl",
-	"sourcePath": "hdf5",
-	"importPath": "hdf5",
+	"sourcePaths": [ "hdf5" ],
+	"importPaths": [ "hdf5" ],
 }

--- a/dub.json
+++ b/dub.json
@@ -6,8 +6,6 @@
 	"license": "Boost-1.0",
 	"libs":["hdf5","hdf5_hl"],
 	"targetType":"sourceLibrary",
-	"dependencies": {
-	},
 	"systemDependencies": "requires HDF5 1.8.15.patch-1 versions of libhdf5 and libhdf5_hl",
 	"sourcePaths": [ "hdf5" ],
 	"importPaths": [ "hdf5" ],

--- a/examples/allocationtime/dub.json
+++ b/examples/allocationtime/dub.json
@@ -16,6 +16,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/allocationtime/dub.selections.json
+++ b/examples/allocationtime/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/attribute/dub.json
+++ b/examples/attribute/dub.json
@@ -19,6 +19,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/attribute/dub.selections.json
+++ b/examples/attribute/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/bitfields/dub.json
+++ b/examples/bitfields/dub.json
@@ -15,6 +15,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/bitfields/dub.selections.json
+++ b/examples/bitfields/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/checksum/dub.json
+++ b/examples/checksum/dub.json
@@ -18,6 +18,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/checksum/dub.selections.json
+++ b/examples/checksum/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/chunk/dub.json
+++ b/examples/chunk/dub.json
@@ -18,6 +18,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/chunk/dub.selections.json
+++ b/examples/chunk/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/chunkread/dub.json
+++ b/examples/chunkread/dub.json
@@ -11,6 +11,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/chunkread/dub.selections.json
+++ b/examples/chunkread/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/complexdatatype/dub.json
+++ b/examples/complexdatatype/dub.json
@@ -12,6 +12,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/complexdatatype/dub.selections.json
+++ b/examples/complexdatatype/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/complextypereadwrite/dub.json
+++ b/examples/complextypereadwrite/dub.json
@@ -30,6 +30,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/complextypereadwrite/dub.selections.json
+++ b/examples/complextypereadwrite/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/creategroupdataset/dub.json
+++ b/examples/creategroupdataset/dub.json
@@ -13,6 +13,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/creategroupdataset/dub.selections.json
+++ b/examples/creategroupdataset/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/datasetrefs/dub.json
+++ b/examples/datasetrefs/dub.json
@@ -20,6 +20,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/datasetrefs/dub.selections.json
+++ b/examples/datasetrefs/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/drivers/dub.json
+++ b/examples/drivers/dub.json
@@ -13,6 +13,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/drivers/dub.selections.json
+++ b/examples/drivers/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/dtransform/dub.json
+++ b/examples/dtransform/dub.json
@@ -26,6 +26,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/dtransform/dub.selections.json
+++ b/examples/dtransform/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/dub.selections.json
+++ b/examples/dub.selections.json
@@ -1,4 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {}
-}

--- a/examples/extendwrite/dub.json
+++ b/examples/extendwrite/dub.json
@@ -8,6 +8,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/extendwrite/dub.selections.json
+++ b/examples/extendwrite/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/externallinks/dub.json
+++ b/examples/externallinks/dub.json
@@ -12,6 +12,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/externallinks/dub.selections.json
+++ b/examples/externallinks/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/iterategroup/dub.json
+++ b/examples/iterategroup/dub.json
@@ -8,6 +8,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/iterategroup/dub.selections.json
+++ b/examples/iterategroup/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/messageshare/dub.json
+++ b/examples/messageshare/dub.json
@@ -8,6 +8,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/messageshare/dub.selections.json
+++ b/examples/messageshare/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/myiterator/dub.json
+++ b/examples/myiterator/dub.json
@@ -8,6 +8,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/myiterator/dub.selections.json
+++ b/examples/myiterator/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/objrefs/dub.json
+++ b/examples/objrefs/dub.json
@@ -15,6 +15,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/objrefs/dub.selections.json
+++ b/examples/objrefs/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/read/dub.json
+++ b/examples/read/dub.json
@@ -8,6 +8,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/read/dub.selections.json
+++ b/examples/read/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/readwrite/dub.json
+++ b/examples/readwrite/dub.json
@@ -8,6 +8,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/readwrite/dub.selections.json
+++ b/examples/readwrite/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/select/dub.json
+++ b/examples/select/dub.json
@@ -17,6 +17,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/select/dub.selections.json
+++ b/examples/select/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/stringattributes/dub.json
+++ b/examples/stringattributes/dub.json
@@ -8,6 +8,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/stringattributes/dub.selections.json
+++ b/examples/stringattributes/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/strings/dub.json
+++ b/examples/strings/dub.json
@@ -8,6 +8,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/strings/dub.selections.json
+++ b/examples/strings/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/subset/dub.json
+++ b/examples/subset/dub.json
@@ -8,6 +8,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/subset/dub.selections.json
+++ b/examples/subset/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/szip/dub.json
+++ b/examples/szip/dub.json
@@ -8,6 +8,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/szip/dub.selections.json
+++ b/examples/szip/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/traits/dub.json
+++ b/examples/traits/dub.json
@@ -18,6 +18,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/traits/dub.selections.json
+++ b/examples/traits/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/traversefile/dub.json
+++ b/examples/traversefile/dub.json
@@ -8,6 +8,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/traversefile/dub.selections.json
+++ b/examples/traversefile/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/traverseobjects/dub.json
+++ b/examples/traverseobjects/dub.json
@@ -15,6 +15,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/traverseobjects/dub.selections.json
+++ b/examples/traverseobjects/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/unlimiteddataset/dub.json
+++ b/examples/unlimiteddataset/dub.json
@@ -17,6 +17,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/unlimiteddataset/dub.selections.json
+++ b/examples/unlimiteddataset/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}

--- a/examples/write/dub.json
+++ b/examples/write/dub.json
@@ -8,6 +8,6 @@
 	"targetType":"executable",
 	"targetPath": "../../build",
 	"dependencies": {
-		"d_hdf5": "~master"
+		"d_hdf5": { "path": "../../" }
 	}
 }

--- a/examples/write/dub.selections.json
+++ b/examples/write/dub.selections.json
@@ -1,6 +1,0 @@
-{
-	"fileVersion": 1,
-	"versions": {
-		"d_hdf5": "~master"
-	}
-}


### PR DESCRIPTION
I was looking at the dub.json and noticed a few low hanging fruits. See each commit message for a more detailed explanation, but the diff is fairly straightforward.